### PR TITLE
Updating the binder and convert settings to module settings

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -18,7 +18,7 @@ component {
 	this.layoutParentLookup = false;
 	this.modelNamespace		= 'swearjar';
 	this.cfmapping			= 'swearjar';
-	this.autoMapModels 		= true;
+	this.autoMapModels 		= false;
 
 	/**
 	 * Configure
@@ -34,31 +34,10 @@ component {
 	* Fired when the module is registered and activated.
 	*/
 	function onLoad(){
-        parseParentSettings();
-        var swearjarSettings = controller.getConfigSettings().swearjar;
 		// Map Library
         binder.map( "swearjar@swearjar" )
-            .initArg( name="libraryFilePath", value=swearjarSettings.libraryFilePath );
-	}
-
-	/**
-	* Fired when the module is unregistered and unloaded
-	*/
-    function onUnload(){}
-    
-    /**
-	* parse parent settings
-	*/
-	private function parseParentSettings(){
-		var oConfig      = controller.getSetting( "ColdBoxConfig" );
-		var configStruct = controller.getConfigSettings();
-		var swearjarDSL  = oConfig.getPropertyMixin( "swearjar", "variables", structnew() );
-
-		//defaults
-		configStruct.swearjar = variables.settings;
-
-		// incorporate settings
-		structAppend( configStruct.swearjar, swearjarDSL, true );
+			.to( "#moduleMapping#.swearjar" )
+            .initArg( name="libraryFilePath", value=settings.libraryFilePath );
 	}
 
 }

--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ box install swearjar
 This package is also a ColdBox module. The module can be configured by creating a `swearjar` configuration structure in your application configuration file (`config/Coldbox.cfc`) with the following settings:
 
 ```js
-swearjar = {
+moduleSettings = {
+  swearjar = {
      libraryFilePath = '' // The path to your chosen profanity library JSON file
+  }
 };
 ```
 You can optionally leave this configuration out and `swearjar` will use the default `en_US.json` file.

--- a/swearjar.cfc
+++ b/swearjar.cfc
@@ -3,7 +3,7 @@
  * Author: Matt Gifford (matt@monkehworks.com)
  * Purpose: A CFML profanity detection and filtering component library
  */
-component accessors="true" {
+component accessors="true" singleton {
 
     property name="badWords" type="struct";
 


### PR DESCRIPTION
BREAKING CHANGE

Updating the settings to new method for ColdBox, ie - use module settings 
Also, updated the binder in the onload to actually map to the swearjar component.
This was failing previously, it was creating a null mapping.