### PR TITLE
Updated to work with CF2016

### DIFF
--- a/swearjar.cfc
+++ b/swearjar.cfc
@@ -82,7 +82,7 @@ component accessors="true" singleton {
 	 */
     public boolean function profane( required string text ){
         var profane = false;
-        this.scan( text = arguments.text, callback = function( word, index, categories ){
+        scan( text = arguments.text, callback = function( word, index, categories ){
             profane = true;
             return false; // stop on first match
         } );
@@ -97,7 +97,7 @@ component accessors="true" singleton {
 	 */
     public struct function scorecard( required string text ){
         var scorecard = {};
-        this.scan( text = arguments.text, callback = function( word, index, categories ){
+        scan( text = arguments.text, callback = function( word, index, categories ){
             for( var i = 1; i <= arrayLen( arguments.categories ); i++ ){
                 var cat = arguments.categories[ i ];
                 if( structKeyExists( scorecard, cat ) ){
@@ -118,7 +118,7 @@ component accessors="true" singleton {
      */
     public struct function words( required string text ){
         var words = {};
-        this.scan( text = arguments.text, callback = function( word, index, categories ){
+        scan( text = arguments.text, callback = function( word, index, categories ){
             words[ arguments.word ] = arguments.categories;
         } );
         return words;
@@ -132,7 +132,7 @@ component accessors="true" singleton {
      */
     public string function censor( required string text ){
         var censored = arguments.text;
-        this.scan( text = arguments.text, callback = function( word, index, categories ){
+        scan( text = arguments.text, callback = function( word, index, categories ){
             censored = replaceNoCase( censored, word, reReplaceNoCase( word, '[a-z]', '*', 'all' ) );
         } );
         return censored;
@@ -149,7 +149,7 @@ component accessors="true" singleton {
         string cssClass = 'swearjar-sugarcoat'
     ){
         var censored = arguments.text;
-        this.scan( text = arguments.text, cssClass = arguments.cssClass, callback = function( word, index, categories, replacements, cssClass ){
+        scan( text = arguments.text, cssClass = arguments.cssClass, callback = function( word, index, categories, replacements, cssClass ){
             if( arrayLen( replacements ) ){
                 var repIndex = ( arrayLen( replacements ) > 1 ) ? randRange( 1, arrayLen( replacements ) ) : 1;
                 var replacement = '<span class="#cssClass#">#replacements[ repIndex ]#</span>';
@@ -169,7 +169,7 @@ component accessors="true" singleton {
      */
     public string function unicorn( required string text ){
         var censored = arguments.text;
-        this.scan( text = arguments.text, callback = function( word, index, categories ){
+        scan( text = arguments.text, callback = function( word, index, categories ){
             censored = replaceNoCase( censored, word, 'unicorn' );
         } );
         return censored;
@@ -187,7 +187,7 @@ component accessors="true" singleton {
         var words         = {};
         var categoryCount = {};
         var wordCount     = {};
-        this.scan( text = arguments.text, callback = function( word, index, categories ){
+        scan( text = arguments.text, callback = function( word, index, categories ){
             profane = true;
             words[ arguments.word ] = arguments.categories;
             censored = replaceNoCase( censored, arguments.word, reReplaceNoCase( arguments.word, '[a-z]', '*', 'all' ) );


### PR DESCRIPTION
The `this` scope was throwing the following error when used outside of the `init` fucntion. Removing `this.` from scan calls fixed the issue.

```
The method scan was not found in component C:/CFusion/cfusion/CustomTags/swearjar.cfc.
Ensure that the method is defined, and that it is spelled correctly.
```