### PR TITLE
Add stripUnsafeSpace() to strip hidden whitespace

### DIFF
--- a/swearjar.cfc
+++ b/swearjar.cfc
@@ -74,6 +74,10 @@ component accessors="true" singleton {
         }
     }
 
+    private string function stripUnsafeSpace(required string text){
+        return javacast("string", arguments.text).replaceAll("#chr(1)#|&##1;|&##xf0001;|#chr(2)#|&##2;|&##xf0002;|#chr(3)#|&##3;|&##xf0003;|#chr(4)#|&##4;|&##xf0004;|#chr(5)#|&##5;|&##xf0005;|#chr(6)#|&##6;|&##xf0006;|#chr(7)#|&##7;|&##xf0007;|#chr(8)#|&##8;|&##xf0008;|#chr(11)#|&##11;|&##xf000b;|#chr(12)#|&##12;|&##xf000c;|#chr(14)#|&##14;|&##xf000e;|#chr(15)#|&##15;|&##xf000f;|#chr(16)#|&##16;|&##xf0010;|#chr(17)#|&##17;|&##xf0011;|#chr(18)#|&##18;|&##xf0012;|#chr(19)#|&##19;|&##xf0013;|#chr(20)#|&##20;|&##xf0014;|#chr(21)#|&##21;|&##xf0015;|#chr(22)#|&##22;|&##xf0016;|#chr(23)#|&##23;|&##xf0017;|#chr(24)#|&##24;|&##xf0018;|#chr(25)#|&##25;|&##xf0019;|#chr(26)#|&##26;|&##xf001a;|#chr(27)#|&##27;|&##xf001b;|#chr(28)#|&##28;|&##xf001c;|#chr(29)#|&##29;|&##xf001d;|#chr(30)#|&##30;|&##xf001e;|#chr(31)#|&##31;|&##xf001f;|#chr(133)#|&##133;|&##xf0085;|#chr(160)#|&##160;|&##xf00a0;|#chr(5760)#|&##5760;|&##xf1680;|#chr(6158)#|&##6158;|&##xf180e;|#chr(8192)#|&##8192;|&##xf2000;|#chr(8193)#|&##8193;|&##xf2001;|#chr(8194)#|&##8194;|&##xf2002;|#chr(8195)#|&##8195;|&##xf2003;|#chr(8196)#|&##8196;|&##xf2004;|#chr(8197)#|&##8197;|&##xf2005;|#chr(8198)#|&##8198;|&##xf2006;|#chr(8199)#|&##8199;|&##xf2007;|#chr(8200)#|&##8200;|&##xf2008;|#chr(8201)#|&##8201;|&##xf2009;|#chr(8202)#|&##8202;|&##xf200a;|#chr(8203)#|&##8203;|&##xf200b;|‌#chr(8204)#|&##8204;|&##xf200c;|‍#chr(8205)#|&##8205;|&##xf200d;|#chr(8206)#|&##8206;|&##xf200e;|#chr(8207)#|&##8207;|&##xf200f;|⁠#chr(8288)#|&##8288;|&##xf2060;|#chr(8232)#|&##8232;|&##xf2028;|#chr(8233)#|&##8233;|&##xf2029;|#chr(8239)#|&##8239;|&##xf202f;|#chr(8287)#|&##8287;|&##xf205f;|#chr(9248)#|&##9248;|&##xf2420;|#chr(9250)#|&##9250;|&##xf2422;|#chr(9251)#|&##9251;|&##xf2423;|#chr(10240)#|&##10240;|&##xf2800;|#chr(12288)#|&##12288;|&##xf3000;|#chr(65279)#|&##65279;|&##xffeff;|#chr(96296)#|&##65296;|&##xfff10;", "");
+    }
+
     /**
 	 * Returns true if `text` contains profanity
 	 *
@@ -82,7 +86,7 @@ component accessors="true" singleton {
 	 */
     public boolean function profane( required string text ){
         var profane = false;
-        this.scan( text = arguments.text, callback = function( word, index, categories ){
+        this.scan( text = stripUnsafeSpace(arguments.text), callback = function( word, index, categories ){
             profane = true;
             return false; // stop on first match
         } );
@@ -97,7 +101,7 @@ component accessors="true" singleton {
 	 */
     public struct function scorecard( required string text ){
         var scorecard = {};
-        this.scan( text = arguments.text, callback = function( word, index, categories ){
+        this.scan( text = stripUnsafeSpace(arguments.text), callback = function( word, index, categories ){
             for( var i = 1; i <= arrayLen( arguments.categories ); i++ ){
                 var cat = arguments.categories[ i ];
                 if( structKeyExists( scorecard, cat ) ){
@@ -118,7 +122,7 @@ component accessors="true" singleton {
      */
     public struct function words( required string text ){
         var words = {};
-        this.scan( text = arguments.text, callback = function( word, index, categories ){
+        this.scan( text = stripUnsafeSpace(arguments.text), callback = function( word, index, categories ){
             words[ arguments.word ] = arguments.categories;
         } );
         return words;
@@ -131,8 +135,8 @@ component accessors="true" singleton {
      * @returns string
      */
     public string function censor( required string text ){
-        var censored = arguments.text;
-        this.scan( text = arguments.text, callback = function( word, index, categories ){
+        var censored = stripUnsafeSpace(arguments.text);
+        this.scan( text = stripUnsafeSpace(arguments.text), callback = function( word, index, categories ){
             censored = replaceNoCase( censored, word, reReplaceNoCase( word, '[a-z]', '*', 'all' ) );
         } );
         return censored;
@@ -148,8 +152,8 @@ component accessors="true" singleton {
         required string text,
         string cssClass = 'swearjar-sugarcoat'
     ){
-        var censored = arguments.text;
-        this.scan( text = arguments.text, cssClass = arguments.cssClass, callback = function( word, index, categories, replacements, cssClass ){
+        var censored = stripUnsafeSpace(arguments.text);
+        this.scan( text = stripUnsafeSpace(arguments.text), cssClass = arguments.cssClass, callback = function( word, index, categories, replacements, cssClass ){
             if( arrayLen( replacements ) ){
                 var repIndex = ( arrayLen( replacements ) > 1 ) ? randRange( 1, arrayLen( replacements ) ) : 1;
                 var replacement = '<span class="#cssClass#">#replacements[ repIndex ]#</span>';
@@ -168,8 +172,8 @@ component accessors="true" singleton {
      * @returns string
      */
     public string function unicorn( required string text ){
-        var censored = arguments.text;
-        this.scan( text = arguments.text, callback = function( word, index, categories ){
+        var censored = stripUnsafeSpace(arguments.text);
+        this.scan( text = stripUnsafeSpace(arguments.text), callback = function( word, index, categories ){
             censored = replaceNoCase( censored, word, 'unicorn' );
         } );
         return censored;
@@ -182,12 +186,12 @@ component accessors="true" singleton {
      * @return struct
      */
     public struct function detailedProfane( required string text ){
-        var censored      = arguments.text;
+        var censored      = stripUnsafeSpace(arguments.text);
         var profane       = false;
         var words         = {};
         var categoryCount = {};
         var wordCount     = {};
-        this.scan( text = arguments.text, callback = function( word, index, categories ){
+        this.scan( text = stripUnsafeSpace(arguments.text), callback = function( word, index, categories ){
             profane = true;
             words[ arguments.word ] = arguments.categories;
             censored = replaceNoCase( censored, arguments.word, reReplaceNoCase( arguments.word, '[a-z]', '*', 'all' ) );


### PR DESCRIPTION
Added private function `stripUnsafeSpace()` to remove hidden whitespaces that make it possible for "visible" swear words to bypass filters using zero-width or non-visible characters.

Here are the unsafe ASCII and UTF-8 characters (and HTML entities) that are stripped so that string can be scanned with better reliability.

| CHARACTER          | DESCRIPTION                                     | DECIMAL |
|--------------------|-------------------------------------------------|    ----:|
| SOH                | Start of Heading                                | 1       |
| STX                | Start of Text                                   | 2       |
| ETX                | End of Text                                     | 3       |
| EOT                | End of Transmission                             | 4       |
| ENQ                | Enquiry                                         | 5       |
| ACK                | Acknowledgment                                  | 6       |
| BEL                | Bell                                            | 7       |
| BS                 | Back Space                                      | 8       |
| VT                 | Vertical Tab                                    | 11      |
| FF                 | Form Feed                                       | 12      |
| SO                 | Shift Out / X-On                                | 14      |
| SI                 | Shift In / X-Off                                | 15      |
| DLE                | Data Line Escape                                | 16      |
| DC1                | Device Control 1 (oft. XON)                     | 17      |
| DC2                | Device Control 2                                | 18      |
| DC3                | Device Control 3 (oft. XOFF)                    | 19      |
| DC4                | Device Control 4                                | 20      |
| NAK                | Negative Acknowledgement                        | 21      |
| SYN                | Synchronous Idle                                | 22      |
| ETB                | End of Transmit Block                           | 23      |
| CAN                | Cancel                                          | 24      |
| EM                 | End of Medium                                   | 25      |
| SUB                | Substitute                                      | 26      |
| ESC                | Escape                                          | 27      |
| FS                 | File Separator                                  | 28      |
| GS                 | Group Separator                                 | 29      |
| RS                 | Record Separator                                | 30      |
| US                 | Unit Separator                                  | 31      |
| NEL                | next line                                       | 133     |
| NBSP               | no-breaking space                               | 160     |
| OGHAM              | OGHAM Space Mark                                | 5760    |
| MONGOLIAN          | Mongolian Vowel Separator                       | 6158    |
| ENQUAD             | EN Quad                                         | 8192    |
| EMQUAD             | EM Quad                                         | 8193    |
| ENSP               | EN Space                                        | 8194    |
| EMSP               | EM Space                                        | 8195    |
| THREE-PER-EM SPACE | Thick Space                                     | 8196    |
| FOUR-PER-EM SPACE  | Mid Space                                       | 8197    |
| SIX-PER-EM SPACE   | Six-per-EM Space                                | 8198    |
| FGMSP              | Figure Space                                    | 8199    |
| PUNSP              | Punctuation Space                               | 8200    |
| THINSPACE          | Thin Space                                      | 8201    |
| HAIRSPACE          | Hair Space                                      | 8202    |
| ZWSP               | zero-width space                                | 8203    |
| ZWNJ               | zero-width non-joiner                           | 8204    |
| ZWJ                | zero-width joiner                               | 8205    |
| LRM                | left-to-right mark                              | 8206    |
| RLM                | right-to-left mark                              | 8207    |
| WJ                 | Word Joiner                                     | 8288    |
| LINSEP             | Line Separator                                  | 8232    |
| PARSEP             | Paragraph Separator                             | 8233    |
| NNBSP              | Narrow No-Break Space                           | 8239    |
| MMASP              | Medium Mathematical Space                       | 8287    |
| SMSP               | Symbol for Space                                | 9248    |
| BLANK              | Blank Symbol                                    | 9250    |
| OPENBOX            | Open Box                                        | 9251    |
| BB                 | Braille blank pattern                           | 10240   |
| IDSP               | Ideographic Space                               | 12288   |
| BOM                | Zero Width No-Break Space (AKA Byte Order Mark) | 65279   |
| FWDZ               | Full-Width Digit Zero                           | 65296   |